### PR TITLE
matrix utilities and some thoughts about norms

### DIFF
--- a/affine.py
+++ b/affine.py
@@ -98,3 +98,12 @@ def frobenius_diff(A1: torch.Tensor, A2: torch.Tensor) -> torch.Tensor:
     A1 and A2 are expected to be of shape (..., d, d)
     """
     return frobenius_norm(A1 - A2)
+
+
+def matrix_exp(log_A: torch.Tensor) -> torch.Tensor:
+    """
+    Given a batch of matrices log_A, compute the matrix exponential exp(log_A). This allows for
+    optimization in the 'unconstrained' logarithm space.
+    """
+    s = log_A.shape
+    return torch.matrix_exp(_enforce_matrix_shape(log_A)).reshape(s)

--- a/affine.py
+++ b/affine.py
@@ -61,7 +61,7 @@ def operator_norm(A: torch.Tensor) -> torch.Tensor:
     This norm is invariant to rotations and translations of the input space.
     """
     # Compute A^T * A
-    AtA = torch.einsum("...ij,...jk->...ik", A, A)
+    AtA = torch.einsum("...ji,...jk->...ik", A, A)
     # Compute eigenvalues of A^T * A
     eigvals = torch.linalg.eigvalsh(AtA)  # Shape (..., d)
     # The operator norm is the square root of the largest eigenvalue

--- a/affine.py
+++ b/affine.py
@@ -1,0 +1,100 @@
+from functools import wraps
+from math import isqrt
+
+import torch
+
+__all__ = [
+    "operator_norm",
+    "operator_diff",
+    "frobenius_norm",
+    "frobenius_diff",
+]
+
+
+def _enforce_matrix_shape(A: torch.Tensor) -> torch.Tensor:
+    if A.ndim == 1:
+        d = isqrt(len(A))
+        if d * d != len(A):
+            raise ValueError("Input 1D tensor length is not a perfect square")
+        return A.view(d, d)
+    elif A.ndim >= 2:
+        s = A.shape
+        if s[-2] != s[-1]:
+            # Try treating the last dimension as flattened square matrix
+            d = isqrt(s[-1])
+            if d * d != s[-1]:
+                raise ValueError("Last dimension is not a perfect square")
+            return A.view(*s[:-1], d, d)
+        else:
+            return A
+    else:
+        raise ValueError(f"Not sure how to handle tensor of shape {A.shape}")
+
+
+def enforce_args_shapes(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        new_args = [
+            _enforce_matrix_shape(arg) if isinstance(arg, torch.Tensor) else arg
+            for arg in args
+        ]
+        new_kwargs = {
+            k: _enforce_matrix_shape(v) if isinstance(v, torch.Tensor) else v
+            for k, v in kwargs.items()
+        }
+        return func(*new_args, **new_kwargs)
+
+    return wrapper
+
+
+@enforce_args_shapes
+def operator_norm(A: torch.Tensor) -> torch.Tensor:
+    """
+    Compute the operator norm (spectral norm) of a matrix A.
+    A is expected to be of shape (..., d, d)
+
+    The operator norm treats the matrix as an operator on a vector space and returns the
+    magnitude of ||A @ u||_2 for the unit vector u that maximizes this value. This is equivalent
+    to the largest singular value of A, which can be computed more stably as the square root of the
+    largest eigenvalue of A^T * A.
+
+    This norm is invariant to rotations and translations of the input space.
+    """
+    # Compute A^T * A
+    AtA = torch.einsum("...ij,...jk->...ik", A, A)
+    # Compute eigenvalues of A^T * A
+    eigvals = torch.linalg.eigvalsh(AtA)  # Shape (..., d)
+    # The operator norm is the square root of the largest eigenvalue
+    op_norm = torch.sqrt(eigvals[..., -1])  # Shape (...)
+    return op_norm
+
+
+@enforce_args_shapes
+def operator_diff(A1: torch.Tensor, A2: torch.Tensor) -> torch.Tensor:
+    """
+    Compute the operator norm of the difference between two matrices A1 and A2.
+    A1 and A2 are expected to be of shape (..., d, d)
+    """
+    return operator_norm(A1 - A2)
+
+
+@enforce_args_shapes
+def frobenius_norm(A: torch.Tensor) -> torch.Tensor:
+    """
+    Compute the Frobenius norm of a matrix A.
+    A is expected to be of shape (..., d, d)
+
+    The Frobenius norm treats the matrix as a vector in R^(d*d) and returns its Euclidean length.
+    Note that this norm is sensitive to rotations of the input space and thus may not be ideal
+    for measuring differences between affine transformations.
+    """
+    return torch.sqrt(torch.sum(A * A, dim=(-2, -1)))  # Shape (...)
+
+
+@enforce_args_shapes
+def frobenius_diff(A1: torch.Tensor, A2: torch.Tensor) -> torch.Tensor:
+    """
+    Compute the Frobenius norm of the difference between two matrices A1 and A2.
+    A1 and A2 are expected to be of shape (..., d, d)
+    """
+    return frobenius_norm(A1 - A2)

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -2,8 +2,15 @@ import unittest
 
 import numpy as np
 import torch
+import torch.testing as tt
 
-from affine import operator_norm, frobenius_norm, matrix_exp
+from affine import (
+    operator_norm,
+    frobenius_norm,
+    matrix_exp,
+    operator_diff,
+    frobenius_diff,
+)
 
 
 class TestLogParameterization(unittest.TestCase):
@@ -11,34 +18,39 @@ class TestLogParameterization(unittest.TestCase):
         log_A = torch.zeros(3, 4)
         A = matrix_exp(log_A)
         assert A.shape == log_A.shape
-        assert torch.allclose(A, torch.eye(2).repeat(3, 1, 1).view(3, 4))
+        tt.assert_close(A, torch.eye(2).repeat(3, 1, 1).view(3, 4))
 
     def test_log_2x2(self):
         log_A = torch.zeros(2, 2)
         A = matrix_exp(log_A)
         assert A.shape == log_A.shape
-        assert torch.allclose(A, torch.eye(2))
+        tt.assert_close(A, torch.eye(2))
 
     def test_log_Bx2x2(self):
         log_A = torch.zeros(3, 2, 2)
         A = matrix_exp(log_A)
         assert A.shape == log_A.shape
-        assert torch.allclose(A, torch.eye(2).repeat(3, 1, 1))
+        tt.assert_close(A, torch.eye(2).repeat(3, 1, 1))
 
     def test_log_Bx3x3(self):
         log_A = torch.zeros(5, 3, 3)
         A = matrix_exp(log_A)
         assert A.shape == log_A.shape
-        assert torch.allclose(A, torch.eye(3).repeat(5, 1, 1))
+        tt.assert_close(A, torch.eye(3).repeat(5, 1, 1))
 
 
 class TestOpNorm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Seed chosen by keyboard-mashing
+        torch.manual_seed(1189357)
+
     def test_operator_norm_2x2(self):
         # Should work on a (2, 2) matrix
         A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
         norm = operator_norm(A)
         assert norm.shape == ()
-        assert torch.isclose(norm, torch.tensor(4.0))
+        tt.assert_close(norm, torch.tensor(4.0))
 
     def test_operator_norm_Bx2x2(self):
         # Should work on a batch of matrices
@@ -46,14 +58,14 @@ class TestOpNorm(unittest.TestCase):
         A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
         norm_batch = operator_norm(A_batch)
         assert norm_batch.shape == (3,)
-        assert torch.allclose(norm_batch, torch.tensor([4.0, 8.0, 12.0]))
+        tt.assert_close(norm_batch, torch.tensor([4.0, 8.0, 12.0]))
 
     def test_operator_norm_3x3(self):
         # Should in principle work on a 3x3 matrix even though we don't use that
         A3 = torch.eye(3)
         norm3 = operator_norm(A3)
         assert norm3.shape == ()
-        assert torch.isclose(norm3, torch.tensor(1.0))
+        tt.assert_close(norm3, torch.tensor(1.0))
 
     def test_operator_norm_flat(self):
         # Should work on flattened square matrices
@@ -62,7 +74,7 @@ class TestOpNorm(unittest.TestCase):
         A_flat = A_batch.view(3, 4)  # Shape (3, 4)
         norm_flat = operator_norm(A_flat)
         assert norm_flat.shape == (3,)
-        assert torch.allclose(norm_flat, torch.tensor([4.0, 8.0, 12.0]))
+        tt.assert_close(norm_flat, torch.tensor([4.0, 8.0, 12.0]))
 
     def test_operator_norm_is_rotation_invariant(self):
         # The operator norm should be invariant under rotations
@@ -80,8 +92,25 @@ class TestOpNorm(unittest.TestCase):
 
         assert torch.isclose(norm_A, norm_A_rotated)
 
+    def test_operator_diff_is_symmetric(self):
+        # Run a batch of 100 randomized tests at once
+        A1 = torch.tensor([[3.0, 0.0], [0.0, 4.0]]).repeat(100, 1, 1) + torch.randn(
+            100, 2, 2
+        )
+        A2 = torch.tensor([[3.0, 0.0], [0.0, 4.0]]).repeat(100, 1, 1) + torch.randn(
+            100, 2, 2
+        )
+        diff_1_2 = operator_diff(A1, A2)
+        diff_2_1 = operator_diff(A2, A1)
+        tt.assert_close(diff_1_2, diff_2_1)
+
 
 class TestFrobNorm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Seed chosen by keyboard-mashing
+        torch.manual_seed(17894165)
+
     def test_frobenius_norm_2x2(self):
         # Should work on a (2, 2) matrix
         A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
@@ -95,7 +124,7 @@ class TestFrobNorm(unittest.TestCase):
         A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
         norm_batch = frobenius_norm(A_batch)
         assert norm_batch.shape == (3,)
-        assert torch.allclose(norm_batch, torch.tensor([5.0, 10.0, 15.0]))
+        tt.assert_close(norm_batch, torch.tensor([5.0, 10.0, 15.0]))
 
     def test_frobenius_norm_3x3(self):
         # Should in principle work on a 3x3 matrix even though we don't use that
@@ -111,7 +140,7 @@ class TestFrobNorm(unittest.TestCase):
         A_flat = A_batch.view(3, 4)  # Shape (3, 4)
         norm_flat = frobenius_norm(A_flat)
         assert norm_flat.shape == (3,)
-        assert torch.allclose(norm_flat, torch.tensor([5.0, 10.0, 15.0]))
+        tt.assert_close(norm_flat, torch.tensor([5.0, 10.0, 15.0]))
 
     def test_frobenius_norm_is_rotation_invariant(self):
         # The frobenius norm is expected to be invariant under rotations
@@ -127,4 +156,16 @@ class TestFrobNorm(unittest.TestCase):
         A_rotated = R @ A @ R.T
         norm_A_rotated = frobenius_norm(A_rotated)
 
-        assert torch.isclose(norm_A, norm_A_rotated)
+        tt.assert_close(norm_A, norm_A_rotated)
+
+    def test_frobenius_diff_is_symmetric(self):
+        # Run a batch of 100 randomized tests at once
+        A1 = torch.tensor([[3.0, 0.0], [0.0, 4.0]]).repeat(100, 1, 1) + torch.randn(
+            100, 2, 2
+        )
+        A2 = torch.tensor([[3.0, 0.0], [0.0, 4.0]]).repeat(100, 1, 1) + torch.randn(
+            100, 2, 2
+        )
+        diff_1_2 = frobenius_diff(A1, A2)
+        diff_2_1 = frobenius_diff(A2, A1)
+        tt.assert_close(diff_1_2, diff_2_1)

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import torch
 
 from affine import operator_norm, frobenius_norm
@@ -37,6 +38,22 @@ class TestOpNorm(unittest.TestCase):
         assert norm_flat.shape == (3,)
         assert torch.allclose(norm_flat, torch.tensor([4.0, 8.0, 12.0]))
 
+    def test_operator_norm_is_rotation_invariant(self):
+        # The operator norm should be invariant under rotations
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        norm_A = operator_norm(A)
+
+        theta = torch.pi / 4  # 45 degrees
+        R = torch.tensor(
+            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]],
+            dtype=torch.float32,
+        )
+
+        A_rotated = R @ A @ R.T
+        norm_A_rotated = operator_norm(A_rotated)
+
+        assert torch.isclose(norm_A, norm_A_rotated)
+
 
 class TestFrobNorm(unittest.TestCase):
     def test_frobenius_norm_2x2(self):
@@ -69,3 +86,19 @@ class TestFrobNorm(unittest.TestCase):
         norm_flat = frobenius_norm(A_flat)
         assert norm_flat.shape == (3,)
         assert torch.allclose(norm_flat, torch.tensor([5.0, 10.0, 15.0]))
+
+    def test_frobenius_norm_is_rotation_invariant(self):
+        # The frobenius norm is expected to be invariant under rotations
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        norm_A = frobenius_norm(A)
+
+        theta = torch.pi / 4  # 45 degrees
+        R = torch.tensor(
+            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]],
+            dtype=torch.float32,
+        )
+
+        A_rotated = R @ A @ R.T
+        norm_A_rotated = frobenius_norm(A_rotated)
+
+        assert torch.isclose(norm_A, norm_A_rotated)

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -1,0 +1,71 @@
+import unittest
+
+import torch
+
+from affine import operator_norm, frobenius_norm
+
+
+class TestOpNorm(unittest.TestCase):
+    def test_operator_norm_2x2(self):
+        # Should work on a (2, 2) matrix
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        norm = operator_norm(A)
+        assert norm.shape == ()
+        assert torch.isclose(norm, torch.tensor(4.0))
+
+    def test_operator_norm_Bx2x2(self):
+        # Should work on a batch of matrices
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
+        norm_batch = operator_norm(A_batch)
+        assert norm_batch.shape == (3,)
+        assert torch.allclose(norm_batch, torch.tensor([4.0, 8.0, 12.0]))
+
+    def test_operator_norm_3x3(self):
+        # Should in principle work on a 3x3 matrix even though we don't use that
+        A3 = torch.eye(3)
+        norm3 = operator_norm(A3)
+        assert norm3.shape == ()
+        assert torch.isclose(norm3, torch.tensor(1.0))
+
+    def test_operator_norm_flat(self):
+        # Should work on flattened square matrices
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
+        A_flat = A_batch.view(3, 4)  # Shape (3, 4)
+        norm_flat = operator_norm(A_flat)
+        assert norm_flat.shape == (3,)
+        assert torch.allclose(norm_flat, torch.tensor([4.0, 8.0, 12.0]))
+
+
+class TestFrobNorm(unittest.TestCase):
+    def test_frobenius_norm_2x2(self):
+        # Should work on a (2, 2) matrix
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        norm = frobenius_norm(A)
+        assert norm.shape == ()
+        assert torch.isclose(norm, torch.tensor(5.0))
+
+    def test_frobenius_norm_Bx2x2(self):
+        # Should work on a batch of matrices
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
+        norm_batch = frobenius_norm(A_batch)
+        assert norm_batch.shape == (3,)
+        assert torch.allclose(norm_batch, torch.tensor([5.0, 10.0, 15.0]))
+
+    def test_frobenius_norm_3x3(self):
+        # Should in principle work on a 3x3 matrix even though we don't use that
+        A3 = torch.eye(3)
+        norm3 = frobenius_norm(A3)
+        assert norm3.shape == ()
+        assert torch.isclose(norm3, torch.sqrt(torch.tensor(3.0)))
+
+    def test_frobenius_norm_flat(self):
+        # Should work on flattened square matrices
+        A = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        A_batch = torch.stack([A, 2 * A, 3 * A])  # Shape (3, 2, 2)
+        A_flat = A_batch.view(3, 4)  # Shape (3, 4)
+        norm_flat = frobenius_norm(A_flat)
+        assert norm_flat.shape == (3,)
+        assert torch.allclose(norm_flat, torch.tensor([5.0, 10.0, 15.0]))

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -3,7 +3,33 @@ import unittest
 import numpy as np
 import torch
 
-from affine import operator_norm, frobenius_norm
+from affine import operator_norm, frobenius_norm, matrix_exp
+
+
+class TestLogParameterization(unittest.TestCase):
+    def test_log_flat(self):
+        log_A = torch.zeros(3, 4)
+        A = matrix_exp(log_A)
+        assert A.shape == log_A.shape
+        assert torch.allclose(A, torch.eye(2).repeat(3, 1, 1).view(3, 4))
+
+    def test_log_2x2(self):
+        log_A = torch.zeros(2, 2)
+        A = matrix_exp(log_A)
+        assert A.shape == log_A.shape
+        assert torch.allclose(A, torch.eye(2))
+
+    def test_log_Bx2x2(self):
+        log_A = torch.zeros(3, 2, 2)
+        A = matrix_exp(log_A)
+        assert A.shape == log_A.shape
+        assert torch.allclose(A, torch.eye(2).repeat(3, 1, 1))
+
+    def test_log_Bx3x3(self):
+        log_A = torch.zeros(5, 3, 3)
+        A = matrix_exp(log_A)
+        assert A.shape == log_A.shape
+        assert torch.allclose(A, torch.eye(3).repeat(5, 1, 1))
 
 
 class TestOpNorm(unittest.TestCase):


### PR DESCRIPTION
This PR includes a new `affine.py` file which contains some logic for handling norms and differences between 2x2 matrices, providing some abstraction for switching between Frobenius norms and Operator norms. It also includes a `matrix_exp` utility so that optimization of `A` matrices can be done in an 'unconstrained' space. Note that `matrix_log(identity_matrix) = zeros`, so if using this parameterization, the `log_A` matrices should be initialized to all-zeros. 

In terms of which norm is best, I think that the operator norm is the most sensible one to use in this context, since it nicely generalizes the idea of a Euclidean norm on `uv`. However, what I've provided here only incorporates 2x2 matrices, not 2x3 affine transforms. It will require more work to generalize this idea to the 8-parameter case with variable origins. This is just a suggestion & a starting-point. I also added some unittests, which I always find indispensable as sanity-checks that things are going as expected.

Some additional thoughts on 6- and 8-parameter cases... the idea of the operator norm is to take two transformations and measure their 'worst-case' difference in how they map some unit-vector $x$

- in the case of just a 2x2 matrix, this is the max over $x$ of $\| A_1 x - A_2 x\|_2 = \|(A_1 - A_2) x\|_2$ where $\| \cdot \|_2$ is the Euclidean norm.
- in the case of a 2x3 affine transform, the straightforward generalization is to maximize $\| (A_1 x + u_1) - (A_2 x + u_2)\|_2 = \| (A_1 - A_2) x + (u_1 - u_2)\|_2$... and this is, importantly, **not** the same as the sum of the norm for the $A$ terms and the norm for the $u$ term. Implementing this is to-do.
- In the 8-parameter case, we should think some more. My current instinct is to do separate norms for the difference-in-origins and the difference-in-6-parameter-affine-transforms.

